### PR TITLE
Remove backwards compatibility with Galactic and Humble.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,6 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-if($ENV{ROS_DISTRO} STREQUAL "galactic")
-  add_definitions(-DGALACTIC)
-endif()
-
-if($ENV{ROS_DISTRO} STREQUAL "humble")
-  add_definitions(-DHUMBLE)
-endif()
-
 # find dependencies
 
 find_package(ament_cmake REQUIRED)

--- a/include/nmea_hardware_interface/geopose_publisher.hpp
+++ b/include/nmea_hardware_interface/geopose_publisher.hpp
@@ -41,7 +41,7 @@ public:
     const rclcpp::NodeOptions & node_options =
       rclcpp::NodeOptions()
         .allow_undeclared_parameters(true)
-        .automatically_declare_parameters_from_overrides(true)) override;
+        .automatically_declare_parameters_from_overrides(true));
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {
@@ -51,12 +51,10 @@ public:
 
   controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
-#if defined(GALACTIC) || defined(HUMBLE)
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init()
   {
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
-#endif
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
     const rclcpp_lifecycle::State & /*previous_state*/) override;
@@ -73,12 +71,8 @@ public:
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-#if defined(GALACTIC) || defined(HUMBLE)
   controller_interface::return_type update(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
-#else
-  controller_interface::return_type update() override;
-#endif
 
 private:
   double publish_rate_;

--- a/include/nmea_hardware_interface/gps_hardware_interface.hpp
+++ b/include/nmea_hardware_interface/gps_hardware_interface.hpp
@@ -18,20 +18,12 @@
 // Headers in ROS
 #include <quaternion_operation/quaternion_operation.h>
 
-#if defined(GALACTIC) || defined(HUMBLE)
 #include <hardware_interface/system_interface.hpp>
-#else
-#include <hardware_interface/base_interface.hpp>
-#endif
 #include <hardware_interface/handle.hpp>
 #include <hardware_interface/hardware_info.hpp>
 #include <hardware_interface/sensor_interface.hpp>
 #include <hardware_interface/types/hardware_interface_return_values.hpp>
-#if defined(GALACTIC) || defined(HUMBLE)
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
-#else
-#include <hardware_interface/types/hardware_interface_status_values.hpp>
-#endif
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/optional.hpp>
@@ -48,34 +40,17 @@
 namespace nmea_hardware_interface
 {
 class GPSHardwareInterface
-#if defined(GALACTIC) || defined(HUMBLE)
 : public hardware_interface::SensorInterface
-#else
-: public hardware_interface::BaseInterface<hardware_interface::SensorInterface>
-#endif
 {
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(GPSHardwareInterface)
 
-#if defined(GALACTIC) || defined(HUMBLE)
-
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init(
     const hardware_interface::HardwareInfo & info) override;
-#else
-
-  hardware_interface::return_type configure(const hardware_interface::HardwareInfo & info) override;
-#endif
 
   ~GPSHardwareInterface();
 
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-
-  // #ifndef GALACTIC
-
-  //   hardware_interface::return_type start() override;
-
-  //   hardware_interface::return_type stop() override;
-  // #endif
 
   hardware_interface::return_type read(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;

--- a/src/geopose_publisher.cpp
+++ b/src/geopose_publisher.cpp
@@ -25,7 +25,7 @@ controller_interface::return_type GeoPosePublisher::init(
   const std::string & controller_name, const std::string & namespace_,
   const rclcpp::NodeOptions & node_options)
 {
-  auto ret = ControllerInterface::init(controller_name);
+  auto ret = ControllerInterface::init(controller_name, "", 0.0, namespace_, node_options);
   if (ret != controller_interface::return_type::OK) {
     return ret;
   }
@@ -95,19 +95,11 @@ GeoPosePublisher::on_configure(const rclcpp_lifecycle::State & /*previous_state*
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-#if defined(GALACTIC) || defined(HUMBLE)
 controller_interface::return_type GeoPosePublisher::update(
   const rclcpp::Time & time, const rclcpp::Duration &)
-#else
-controller_interface::return_type GeoPosePublisher::update()
-#endif
 {
   auto node = get_node();
-#if defined(GALACTIC) || defined(HUMBLE)
   const auto now = time;
-#else
-  const auto now = node->get_clock()->now();
-#endif
   if (isfirsttime) {
     next_update_time_ = now.seconds();
     isfirsttime = false;

--- a/src/gps_hardware_interface.cpp
+++ b/src/gps_hardware_interface.cpp
@@ -22,43 +22,25 @@
 
 namespace nmea_hardware_interface
 {
-#if defined(GALACTIC) || defined(HUMBLE)
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 GPSHardwareInterface::on_init(const hardware_interface::HardwareInfo & info)
-#else
-hardware_interface::return_type GPSHardwareInterface::configure(
-  const hardware_interface::HardwareInfo & info)
-#endif
 {
   device_file_ = info.hardware_parameters.at("device_file");
   baud_rate_ = std::stoi(info.hardware_parameters.at("baud_rate"));
   frame_id_ = info.hardware_parameters.at("frame_id");
   connectSerialPort();
   using namespace std::chrono_literals;
-// timer_ = rclcpp::create_wall_timer(
-//        1000ms, std::bind(&GPSHardwareInterface::timerCallback, this));
-#if defined(GALACTIC) || defined(HUMBLE)
   if (
     SensorInterface::on_init(info) !=
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS) {
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
-#else
-  if (configure_default(info) != hardware_interface::return_type::OK) {
-    return hardware_interface::return_type::ERROR;
-  }
-#endif
   if (info.joints.size() != 1) {
     throw std::runtime_error("joint size should be 1");
   }
   joint_ = info.joints[0].name;
 
-#if defined(GALACTIC) || defined(HUMBLE)
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-#else
-  status_ = hardware_interface::status::CONFIGURED;
-  return hardware_interface::return_type::OK;
-#endif
 }
 
 GPSHardwareInterface::~GPSHardwareInterface()
@@ -79,23 +61,6 @@ std::vector<hardware_interface::StateInterface> GPSHardwareInterface::export_sta
 
   return state_interfaces;
 }
-
-// #ifndef GALACTIC
-// hardware_interface::return_type GPSHardwareInterface::start()
-// {
-//   status_ = hardware_interface::status::STARTED;
-//   togeopose_thread_ = boost::thread(boost::bind(&GPSHardwareInterface::nmea_to_geopose, this));
-//   return hardware_interface::return_type::OK;
-// }
-
-// hardware_interface::return_type GPSHardwareInterface::stop()
-// {
-//   io_thread_.join();
-//   togeopose_thread_.join();
-//   status_ = hardware_interface::status::STOPPED;
-//   return hardware_interface::return_type::OK;
-// }
-// #endif
 
 hardware_interface::return_type GPSHardwareInterface::read(
   const rclcpp::Time & time, const rclcpp::Duration & period)


### PR DESCRIPTION
That is, the code should work going forward, so we don't need this backwards compatibility code in particular.

I test compiled this on Humble (Ubuntu 22.04), Iron (Ubuntu 22.04), and Rolling (Ubuntu 24.04), and it seems to compile in all of those places.